### PR TITLE
Added an "Autodetect folder" button for first run library screen

### DIFF
--- a/src/RequestAPI.d.ts
+++ b/src/RequestAPI.d.ts
@@ -36,6 +36,7 @@ export type RequestAPI = {
   "queue::shuffle": () => void,
 
   "dir::select": () => Optional<string>,
+  "dir::autoGetOsuSongsDir": () => Optional<string>,
   "dir::submit": (dir: string) => void,
 
   "error::dismissed": () => void,

--- a/src/main/router/dir-router.ts
+++ b/src/main/router/dir-router.ts
@@ -1,6 +1,7 @@
 import { Router } from '../lib/route-pass/Router';
 import { none, some } from '../lib/rust-like-utils-backend/Optional';
 import { dialog } from 'electron';
+import path from "path";
 
 
 
@@ -17,6 +18,14 @@ Router.respond("dir::select", () => {
   }
 
   return some(path[0]);
+});
+
+Router.respond("dir::autoGetOsuSongsDir", () => {
+  if (process.env.LOCALAPPDATA === undefined) {
+    return none();
+  }
+
+  return some(path.join(process.env.LOCALAPPDATA, "osu!", "Songs"));
 });
 
 Router.respond("dir::submit", (_evt, dir) => {

--- a/src/renderer/src/components/scenes/DirSelectScene.tsx
+++ b/src/renderer/src/components/scenes/DirSelectScene.tsx
@@ -1,8 +1,6 @@
 import { createSignal } from 'solid-js';
 import '../../assets/css/scenes/dir-select.css';
 
-
-
 export default function DirSelectScene() {
   const [dir, setDir] = createSignal("")
 
@@ -13,6 +11,15 @@ export default function DirSelectScene() {
     }
 
     setDir(opt.value);
+  }
+
+  const autodetectDir = async () => {
+    const autoGetDir = await window.api.request("dir::autoGetOsuSongsDir");
+    if (autoGetDir.isNone) {
+      return;
+    }
+
+    setDir(autoGetDir.value);
   }
 
   const submitDir = async () => {
@@ -27,6 +34,7 @@ export default function DirSelectScene() {
           {dir() === "" ? "[No folder selected]" : dir()}
         </code>
         <div class="row">
+          <button onClick={autodetectDir}>Autodetect folder</button>
           <button onClick={selectDir}>Select folder</button>
           <button onClick={submitDir}>Submit</button>
         </div>


### PR DESCRIPTION
Having to select my osu! folder felt like an annoying amount of extra clicks for me, since I have my directory in the default place. So I decided to add this real quick.

I added a small route to [dir-router.ts](https://github.com/Plextora/osu-radio/commit/92ca7ebaeb4ba7abd8b10af4f7ffde8d17fb72ec#diff-c81236bff7a170e5bf593c80c50d2b2f0bb70ebe001deda798bffafa1aadac52R23) that actually does all of the getting the default path stuff. I'm not sure if this is a good way to do it, but it seemed like the least painful way to do it.