### PR TITLE
Fix file paths on non-Windows systems

### DIFF
--- a/src/renderer/src/lib/Music.ts
+++ b/src/renderer/src/lib/Music.ts
@@ -15,7 +15,7 @@ const player = new Audio();
 
 
 
-const [media, setMedia] = createSignal<URL>();
+const [media, setMedia] = createSignal<string>();
 
 
 
@@ -86,7 +86,7 @@ export { isPlaying }
 
 
 
-async function getCurrent(): Promise<{ song: Song, media: URL } | undefined> {
+async function getCurrent(): Promise<{ song: Song, media: string } | undefined> {
   const song = await window.api.request("queue::current");
 
   if (song.isNone) {
@@ -99,11 +99,9 @@ async function getCurrent(): Promise<{ song: Song, media: URL } | undefined> {
     return;
   }
 
-  const media = new URL(resource.value);
-
   return {
     song: song.value,
-    media
+    media: resource.value
   };
 }
 
@@ -122,8 +120,8 @@ export async function play(): Promise<void> {
 
   const m = media();
 
-  if (m !== undefined && player.src !== m.href) {
-    player.src = m.href;
+  if (m !== undefined && player.src !== m) {
+    player.src = m;
   }
 
   player.volume = calculateVolume();
@@ -148,7 +146,7 @@ export async function next() {
     return;
   }
 
-  player.src = current.media.href;
+  player.src = current.media;
   setMedia(current.media);
 
   if (isPlaying() === true) {
@@ -167,7 +165,7 @@ export async function previous() {
     return;
   }
 
-  player.src = current.media.href;
+  player.src = current.media;
   setMedia(current.media);
 
   if (isPlaying() === true) {
@@ -229,7 +227,7 @@ createEffect(() => {
 
 
 
-const [writeVolume, ] = delay(async (volume: number) => {
+const [writeVolume,] = delay(async (volume: number) => {
   await window.api.request("settings::write", "volume", volume);
 }, 200);
 createEffect(async () => {
@@ -264,7 +262,7 @@ window.api.listen("queue::songChanged", async (s) => {
     return;
   }
 
-  setMedia(new URL(resource.value));
+  setMedia(resource.value);
   setSong(s);
   await play();
 });
@@ -272,7 +270,7 @@ window.api.listen("queue::songChanged", async (s) => {
 
 
 player.addEventListener("ended", async () => {
-    await next();
+  await next();
 });
 
 const OFFSET = 0;
@@ -307,5 +305,5 @@ function currentBPM(offset: number, changes: number[][]): Optional<number> {
         }
     }
 
-    return some(msToBPM(changes[changes.length - 1][BPM]));
+  return some(msToBPM(changes[changes.length - 1][BPM]));
 }

--- a/src/renderer/src/lib/tungsten/resource.ts
+++ b/src/renderer/src/lib/tungsten/resource.ts
@@ -9,7 +9,7 @@ export async function getResourcePath(id: ResourceID | undefined): Promise<strin
     return "";
   }
 
-  return new URL(result.value).href;
+  return result.value
 }
 
 


### PR DESCRIPTION
`media` was being used for file paths, but had type URL.

File paths are not URLs on any major operating system, but on Windows this was working purely coincidentally, since Windows file paths start with `C:` (or some other drive letter), which matches the URL protocol pattern. On Linux and MacOS file systems, file paths start with `/`, which is not accepted by URL.

With this change, the application works on Linux. In theory it should also work on MacOS, but I've only tested Linux.